### PR TITLE
Add protocols option to bypass is-absolute package regex

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ exports[`should add a rel 1`] = `
 <p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
 <p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\" rel=\\"nofollow\\">external</a>.</p>
 <p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\">test@example.com</a></p>
 "
 `;
 
@@ -13,6 +14,7 @@ exports[`should add a target 1`] = `
 <p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
 <p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\" target=\\"_blank\\">external</a>.</p>
 <p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\">test@example.com</a></p>
 "
 `;
 
@@ -21,6 +23,16 @@ exports[`should add both 1`] = `
 <p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
 <p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\" target=\\"_blank\\" rel=\\"nofollow\\">external</a>.</p>
 <p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\">test@example.com</a></p>
+"
+`;
+
+exports[`should add default target or rel to mailto links 1`] = `
+"<p><a href=\\"https://github.com/remarkjs/remark\\" target=\\"_blank\\" rel=\\"nofollow noopener noreferrer\\">remark</a></p>
+<p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
+<p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\" target=\\"_blank\\" rel=\\"nofollow noopener noreferrer\\">external</a>.</p>
+<p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\" target=\\"_blank\\" rel=\\"nofollow noopener noreferrer\\">test@example.com</a></p>
 "
 `;
 
@@ -29,6 +41,7 @@ exports[`should add the defaults when without options 1`] = `
 <p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
 <p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\" target=\\"_blank\\" rel=\\"nofollow noopener noreferrer\\">external</a>.</p>
 <p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\">test@example.com</a></p>
 "
 `;
 
@@ -37,5 +50,6 @@ exports[`should do nothing if both are set to false 1`] = `
 <p><a href=\\"./example.md\\">relative link</a> and <a href=\\"#fragment\\">fragment link</a></p>
 <p>[missing][], <a href=\\"#local\\">local</a>, and <a href=\\"https://github.com/remarkjs/remark\\">external</a>.</p>
 <p><a href=\\".\\">current</a> <a href=\\"..\\">up</a> <a href=\\"example.md\\">relative link without ./</a></p>
+<p><a href=\\"mailto:test@example.com\\">test@example.com</a></p>
 "
 `;

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -14,7 +14,9 @@ var input = [
   '[current](.) [up](..) [relative link without ./](example.md)',
   '',
   '[local]: #local',
-  '[external]: https://github.com/remarkjs/remark'
+  '[external]: https://github.com/remarkjs/remark',
+  '',
+  '<mailto:test@example.com>'
 ].join('\n')
 
 test('should add the defaults when without options', function() {
@@ -61,6 +63,16 @@ test('should add both', function() {
   expect(
     remark()
       .use(externalLinks, {target: '_blank', rel: 'nofollow'})
+      .use(html)
+      .processSync(input)
+      .toString()
+  ).toMatchSnapshot()
+})
+
+test('should add default target or rel to mailto links', function() {
+  expect(
+    remark()
+      .use(externalLinks, {protocols: ['http', 'https', 'mailto']})
       .use(html)
       .processSync(input)
       .toString()

--- a/index.js
+++ b/index.js
@@ -28,14 +28,14 @@ function externalLinks(options) {
 
     function visitor(node) {
       var ctx = node.type === 'link' ? node : definition(node.identifier)
+
+      if (!ctx) return
+
+      var protocol = ctx.url.slice(0, ctx.url.indexOf(':'))
       var data
       var props
 
-      if (
-        ctx &&
-        isAbsoluteURL(ctx.url) &&
-        protocols.includes(ctx.url.slice(0, ctx.url.indexOf(':')))
-      ) {
+      if (isAbsoluteURL(ctx.url) && protocols.indexOf(protocol) !== -1) {
         data = node.data || (node.data = {})
         props = data.hProperties || (data.hProperties = {})
 

--- a/index.js
+++ b/index.js
@@ -7,11 +7,13 @@ module.exports = externalLinks
 
 var defaultTarget = '_blank'
 var defaultRel = ['nofollow', 'noopener', 'noreferrer']
+var defaultProtocols = ['http', 'https']
 
 function externalLinks(options) {
   var opts = options || {}
   var target = opts.target
   var rel = opts.rel
+  var protocols = opts.protocols || defaultProtocols
 
   if (typeof rel === 'string') {
     rel = spaceSeparated(rel)
@@ -29,7 +31,11 @@ function externalLinks(options) {
       var data
       var props
 
-      if (ctx && isAbsoluteURL(ctx.url)) {
+      if (
+        ctx &&
+        isAbsoluteURL(ctx.url) &&
+        protocols.includes(ctx.url.slice(0, ctx.url.indexOf(':')))
+      ) {
         data = node.data || (node.data = {})
         props = data.hProperties || (data.hProperties = {})
 

--- a/readme.md
+++ b/readme.md
@@ -62,12 +62,17 @@ Pass `false` to not set `rel`s on links.
 > When using a `target`, add [`noopener` and `noreferrer`][mdn-a] to avoid
 > exploitation of the `window.opener` API.
 
+###### `options.protocols`
+
+Protocols used to filter against the [is-absolute](https://www.npmjs.com/package/is-absolute) package.
+(`Array.<string>`, default: `['http', 'https']`).
+
 ## Contribute
 
 See [`contributing.md` in `remarkjs/remark`][contributing] for ways to get
 started.
 
-This organisation has a [Code of Conduct][coc].  By interacting with this
+This organisation has a [Code of Conduct][coc]. By interacting with this
 repository, organisation, or community you agree to abide by its terms.
 
 ## License
@@ -75,39 +80,21 @@ repository, organisation, or community you agree to abide by its terms.
 [MIT][license] © [Cédric Delpoux][author]
 
 [build-badge]: https://img.shields.io/travis/remarkjs/remark-external-links.svg
-
 [build]: https://travis-ci.org/remarkjs/remark-external-links
-
 [coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark-external-links.svg
-
 [coverage]: https://codecov.io/github/remarkjs/remark-external-links
-
 [downloads-badge]: https://img.shields.io/npm/dm/remark-external-links.svg
-
 [downloads]: https://www.npmjs.com/package/remark-external-links
-
 [chat-badge]: https://img.shields.io/badge/join%20the%20community-on%20spectrum-7b16ff.svg
-
 [chat]: https://spectrum.chat/unified/remark
-
 [sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
-
 [backers-badge]: https://opencollective.com/unified/backers/badge.svg
-
 [collective]: https://opencollective.com/unified
-
 [license]: license
-
 [author]: https://xuopled.netlify.com
-
 [npm]: https://docs.npmjs.com/cli/install
-
 [remark]: https://github.com/remarkjs/remark
-
 [contributing]: https://github.com/remarkjs/remark/blob/master/contributing.md
-
 [coc]: https://github.com/remarkjs/remark/blob/master/code-of-conduct.md
-
 [mdn-rel]: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
-
 [mdn-a]: https://developer.mozilla.org/en/docs/Web/HTML/Element/a

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Protocols used to filter against the [is-absolute](https://www.npmjs.com/package
 See [`contributing.md` in `remarkjs/remark`][contributing] for ways to get
 started.
 
-This organisation has a [Code of Conduct][coc]. By interacting with this
+This organisation has a [Code of Conduct][coc].  By interacting with this
 repository, organisation, or community you agree to abide by its terms.
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Pass `false` to not set `rel`s on links.
 
 ###### `options.protocols`
 
-Protocols used to filter against the [is-absolute](https://www.npmjs.com/package/is-absolute) package.
+Allows additional protocols to be checked; such as `mailto:`, `tel:`, etc.
 (`Array.<string>`, default: `['http', 'https']`).
 
 ## Contribute
@@ -80,21 +80,39 @@ repository, organisation, or community you agree to abide by its terms.
 [MIT][license] © [Cédric Delpoux][author]
 
 [build-badge]: https://img.shields.io/travis/remarkjs/remark-external-links.svg
+
 [build]: https://travis-ci.org/remarkjs/remark-external-links
+
 [coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark-external-links.svg
+
 [coverage]: https://codecov.io/github/remarkjs/remark-external-links
+
 [downloads-badge]: https://img.shields.io/npm/dm/remark-external-links.svg
+
 [downloads]: https://www.npmjs.com/package/remark-external-links
+
 [chat-badge]: https://img.shields.io/badge/join%20the%20community-on%20spectrum-7b16ff.svg
+
 [chat]: https://spectrum.chat/unified/remark
+
 [sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
+
 [backers-badge]: https://opencollective.com/unified/backers/badge.svg
+
 [collective]: https://opencollective.com/unified
+
 [license]: license
+
 [author]: https://xuopled.netlify.com
+
 [npm]: https://docs.npmjs.com/cli/install
+
 [remark]: https://github.com/remarkjs/remark
+
 [contributing]: https://github.com/remarkjs/remark/blob/master/contributing.md
+
 [coc]: https://github.com/remarkjs/remark/blob/master/code-of-conduct.md
+
 [mdn-rel]: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
+
 [mdn-a]: https://developer.mozilla.org/en/docs/Web/HTML/Element/a


### PR DESCRIPTION
Issue: https://github.com/remarkjs/remark-external-links/issues/9

Was getting some false-positives with the `indexOf` example provided; any issue with going with `includes()`? 

Thanks!