### PR TITLE
Additional options to allow more sophisticated examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function externalLinks(options) {
   var protocols = settings.protocols || defaultProtocols
   var content = settings.content
   var contentProperties = settings.contentProperties || {}
+  var transformChildren = settings.transformChildren
 
   if (typeof rel === 'string') {
     rel = spaceSeparated(rel)
@@ -53,6 +54,10 @@ function externalLinks(options) {
 
         if (rel !== false) {
           props.rel = (rel || defaultRel).concat()
+        }
+        
+        if (typeof transformChildren === 'function') {
+          node.children = transformChildren(node.children)
         }
 
         if (content) {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function externalLinks(options) {
   var protocols = settings.protocols || defaultProtocols
   var contentProperties = settings.contentProperties || {}
   var transformChildren = settings.transformChildren
+  var beforeContent = settings.beforeContent
 
   if (typeof rel === 'string') {
     rel = spaceSeparated(rel)
@@ -69,6 +70,10 @@ function externalLinks(options) {
           // `fragment` is not a known mdast node, but unknown nodes with
           // children are handled as elements by `mdast-util-to-hast`:
           // See: <https://github.com/syntax-tree/mdast-util-to-hast#notes>.
+          if (beforeContent) {
+            node.children.push(beforeContent)
+          }
+          
           node.children.push({
             type: 'fragment',
             children: [],

--- a/index.js
+++ b/index.js
@@ -23,10 +23,6 @@ function externalLinks(options) {
     rel = spaceSeparated(rel)
   }
 
-  if (content && typeof content === 'object' && !('length' in content)) {
-    content = [content]
-  }
-
   return transform
 
   function transform(tree) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ function externalLinks(options) {
   var target = settings.target
   var rel = settings.rel
   var protocols = settings.protocols || defaultProtocols
-  var content = settings.content
   var contentProperties = settings.contentProperties || {}
   var transformChildren = settings.transformChildren
 
@@ -47,6 +46,12 @@ function externalLinks(options) {
       if (absolute(ctx.url) && protocols.indexOf(protocol) !== -1) {
         data = node.data || (node.data = {})
         props = data.hProperties || (data.hProperties = {})
+        
+        let content = typeof settings.content === 'function' ? settings.content(ctx.url) : settings.content
+
+        if (typeof content === 'object' && !('length' in content)) {
+          content = [content]
+        }
 
         if (target !== false) {
           props.target = target || defaultTarget


### PR DESCRIPTION
I'd like to style the existing `children` of the link. The goal is to start with a link like this:

```markdown
[a link](http://example.com/some/path)
```

And be able to generate something like that:

```html
<a href="http://example.com/some/path" rel="noopener noreferrer">
  <span class="link-content">a link</span>
  &#65279;
  <span class="link-hint">
    <img src="http://favicon-api.example.com/?domain=example.com">
  </span>
</a>
```

What's not possible today is:
- Wrapping the "original content" into a specified wrapper (`.link-content` span from the example above)
- Changing the `content` depending on original link href
- Adding something in between the wrapped "original content" and the additional content that's wrapped into the `.link-hint` span

To reach the desired result, I'm using this with:
```javascript
{
  rel: 'noopener noreferrer',
  content: linkUrl => [
    {
      type: 'element',
      tagName: 'img',
      properties: {
        src: `http://favicon-api.example.com/?domain=${new URL(linkUrl).hostname}`
      },
    },
  ],
  contentProperties: {
    class: 'link-hint',
  },
  beforeContent: {
    type: 'text',
    value: '﻿',
  },
  transformChildren: (children) => {
    return [
      {
        type: 'fragment',
        children: [],
        data: {
          hName: 'span',
          hChildren: children,
          hProperties: {
            class: 'link-content',
          },
        },
      },
    ]
  },
}
```

I know it's a lot, but the result is really nice and it's not something i could do with the existing library.

Can you think of better/easier APIs to reach the results i want? Would love to discuss!