### PR TITLE
Add support for boolean as type in `rel`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ declare namespace remarkExternalLinks {
      *
      * @defaultValue ['nofollow', 'noopener', 'noreferrer']
      */
-    rel?: string[] | string
+    rel?: string[] | string | boolean
     /**
      * Protocols to check, such as `mailto` or `tel` (`Array.<string>`, default:
      * `['http', 'https']`).

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ declare namespace remarkExternalLinks {
      *
      * @defaultValue ['nofollow', 'noopener', 'noreferrer']
      */
-    rel?: string[] | string | boolean
+    rel?: string[] | string | false
     /**
      * Protocols to check, such as `mailto` or `tel` (`Array.<string>`, default:
      * `['http', 'https']`).


### PR DESCRIPTION
Production build failed because there is no `boolean type for `rel: true/false` in **remark-external-links** plugin. So I added `boolean` type for typescript in the`/types/index.d.ts. file.
